### PR TITLE
Add encrypted remote shell client and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # revshell
-Simulate a fully interactive SSH shell terminal environment using Go to execute commands.
+
+Simulate a fully interactive SSH-style shell terminal environment using Go to execute commands over an encrypted channel.
+
+## Features
+
+- Long-lived TCP connections between server and client.
+- Interactive remote shell that supports running arbitrary commands, `cd`, and exiting with `exit`.
+- Pluggable stream encryption with selectable cipher suites (`aes`, `xor`) and the ability to register custom algorithms.
+- Configurable prompt template, initial working directory, and shell executable.
+
+## Building
+
+```bash
+go build ./cmd/server
+go build ./cmd/client
+```
+
+## Usage
+
+Start the server (listen on port 2222 by default):
+
+```bash
+./server -pass mysecret -listen 0.0.0.0:2222 -cipher aes
+```
+
+Connect with the client:
+
+```bash
+./client -addr 127.0.0.1:2222 -pass mysecret -cipher aes
+```
+
+Once connected you are greeted with a prompt similar to `user@host /current/path$`. Type commands exactly as you would in an SSH session. Use `exit` to terminate the session.
+
+### Prompt customization
+
+The server accepts a `-prompt` flag allowing placeholders that are expanded on every command:
+
+- `{{.USER}}` – current user name as seen by the server.
+- `{{.HOST}}` – host name of the server machine.
+- `{{.CWD}}` – absolute path of the current working directory.
+- `{{.BASENAME}}` – basename of the current working directory.
+
+For example:
+
+```bash
+./server -pass mysecret -prompt "[{{.BASENAME}}]$ "
+```
+
+### Cipher suites
+
+Two cipher suites are included:
+
+- `aes` – AES-CTR mode with per-session nonces and independent streams for each direction.
+- `xor` – lightweight XOR stream cipher derived from the shared secret (demonstrates how to plug in custom algorithms; use for testing only).
+
+Additional ciphers can be registered at runtime using `secureio.RegisterCipherSuite`.
+
+### Notes
+
+- Both server and client must be launched with the same passphrase and cipher suite.
+- The `-shell` flag allows switching to shells such as `/bin/bash` if available.
+- Keep the terminal window open while the client is connected to maintain the long-lived session.

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"revshell/pkg/secureio"
+)
+
+func main() {
+	available := strings.Join(secureio.ListCipherSuites(), ", ")
+	addr := flag.String("addr", "127.0.0.1:2222", "remote server address")
+	pass := flag.String("pass", "", "shared passphrase used to derive encryption keys")
+	cipherName := flag.String("cipher", "aes", fmt.Sprintf("cipher suite to use (%s)", available))
+	flag.Parse()
+
+	if *pass == "" {
+		fmt.Fprintln(os.Stderr, "client: passphrase must be provided via -pass")
+		os.Exit(1)
+	}
+
+	conn, err := net.Dial("tcp", *addr)
+	if err != nil {
+		log.Fatalf("client: failed to connect to %s: %v", *addr, err)
+	}
+	defer conn.Close()
+
+	reader, writer, err := secureio.Handshake(conn, false, *pass, *cipherName)
+	if err != nil {
+		log.Fatalf("client: handshake failed: %v", err)
+	}
+
+	log.Printf("client: connected to %s using %s cipher", *addr, *cipherName)
+
+	doneReading := make(chan error, 1)
+	doneWriting := make(chan error, 1)
+
+	go func() {
+		_, err := io.Copy(os.Stdout, reader)
+		doneReading <- err
+	}()
+
+	go func() {
+		_, err := io.Copy(writer, os.Stdin)
+		if tcpConn, ok := conn.(*net.TCPConn); ok {
+			_ = tcpConn.CloseWrite()
+		}
+		doneWriting <- err
+	}()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	var readErr error
+	select {
+	case readErr = <-doneReading:
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			log.Printf("client: read error: %v", readErr)
+		}
+	case sig := <-sigCh:
+		log.Printf("client: received signal %s, shutting down", sig)
+	}
+
+	_ = conn.Close()
+	if writeErr := <-doneWriting; writeErr != nil && !errors.Is(writeErr, os.ErrClosed) {
+		log.Printf("client: write error: %v", writeErr)
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"revshell/pkg/secureio"
+	"revshell/pkg/terminal"
+)
+
+type serverOptions struct {
+	listenAddr string
+	passphrase string
+	cipher     string
+	shell      string
+	prompt     string
+	workdir    string
+}
+
+func main() {
+	opts := parseFlags()
+
+	listener, err := net.Listen("tcp", opts.listenAddr)
+	if err != nil {
+		log.Fatalf("server: failed to listen on %s: %v", opts.listenAddr, err)
+	}
+	defer listener.Close()
+
+	log.Printf("server: listening on %s using %s cipher", opts.listenAddr, opts.cipher)
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				log.Printf("server: temporary accept error: %v", err)
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
+			log.Printf("server: stopping listener due to error: %v", err)
+			return
+		}
+
+		go handleConnection(conn, opts)
+	}
+}
+
+func parseFlags() serverOptions {
+	available := strings.Join(secureio.ListCipherSuites(), ", ")
+	listen := flag.String("listen", "0.0.0.0:2222", "address to listen on")
+	pass := flag.String("pass", "", "shared passphrase used to derive encryption keys")
+	cipherName := flag.String("cipher", "aes", fmt.Sprintf("cipher suite to use (%s)", available))
+	shell := flag.String("shell", "/bin/sh", "shell executable used to run commands")
+	prompt := flag.String("prompt", "", "prompt template (supports {{.USER}}, {{.HOST}}, {{.CWD}}, {{.BASENAME}})")
+	workdir := flag.String("workdir", "", "initial working directory for new sessions")
+	flag.Parse()
+
+	if *pass == "" {
+		fmt.Fprintln(os.Stderr, "server: passphrase must be provided via -pass")
+		os.Exit(1)
+	}
+
+	return serverOptions{
+		listenAddr: *listen,
+		passphrase: *pass,
+		cipher:     *cipherName,
+		shell:      *shell,
+		prompt:     *prompt,
+		workdir:    *workdir,
+	}
+}
+
+func handleConnection(conn net.Conn, opts serverOptions) {
+	defer conn.Close()
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		if err := tcpConn.SetKeepAlive(true); err == nil {
+			_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
+		}
+	}
+
+	log.Printf("server: accepted connection from %s", conn.RemoteAddr())
+
+	reader, writer, err := secureio.Handshake(conn, true, opts.passphrase, opts.cipher)
+	if err != nil {
+		log.Printf("server: handshake failed for %s: %v", conn.RemoteAddr(), err)
+		return
+	}
+
+	sessionOpts := terminal.Options{Prompt: opts.prompt, Shell: opts.shell, InitialDir: opts.workdir}
+	session, err := terminal.NewSession(reader, writer, sessionOpts)
+	if err != nil {
+		log.Printf("server: failed to create session for %s: %v", conn.RemoteAddr(), err)
+		return
+	}
+
+	if err := session.Run(); err != nil {
+		log.Printf("server: session for %s ended with error: %v", conn.RemoteAddr(), err)
+	} else {
+		log.Printf("server: session for %s closed", conn.RemoteAddr())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module revshell
+
+go 1.24.3

--- a/pkg/secureio/handshake.go
+++ b/pkg/secureio/handshake.go
@@ -1,0 +1,245 @@
+package secureio
+
+import (
+	"bufio"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sort"
+)
+
+// Handshake establishes a secure reader and writer on top of the provided
+// connection using the requested cipher suite. The same passphrase must be
+// supplied on both sides of the connection.
+func Handshake(conn net.Conn, isServer bool, passphrase, cipherName string) (io.Reader, io.Writer, error) {
+	suite, err := getCipherSuite(cipherName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return suite.handshake(conn, isServer, passphrase)
+}
+
+type cipherSuite interface {
+	handshake(conn net.Conn, isServer bool, passphrase string) (io.Reader, io.Writer, error)
+	Name() string
+}
+
+var registeredSuites = map[string]cipherSuite{
+	"aes": &aesSuite{},
+	"xor": &xorSuite{},
+}
+
+func getCipherSuite(name string) (cipherSuite, error) {
+	suite, ok := registeredSuites[name]
+	if !ok {
+		return nil, fmt.Errorf("secureio: unknown cipher suite %q", name)
+	}
+	return suite, nil
+}
+
+func deriveKey(passphrase string) []byte {
+	sum := sha256.Sum256([]byte(passphrase))
+	return sum[:]
+}
+
+func deriveBytes(direction string, serverNonce, clientNonce []byte, size int) []byte {
+	h := sha256.New()
+	h.Write([]byte(direction))
+	h.Write(serverNonce)
+	h.Write(clientNonce)
+	sum := h.Sum(nil)
+	if size <= len(sum) {
+		return sum[:size]
+	}
+
+	buf := make([]byte, size)
+	copy(buf, sum)
+	pos := len(sum)
+	for pos < size {
+		h.Reset()
+		h.Write(sum)
+		sum = h.Sum(nil)
+		n := copy(buf[pos:], sum)
+		pos += n
+	}
+	return buf
+}
+
+const (
+	directionServerToClient = "srv->cli"
+	directionClientToServer = "cli->srv"
+)
+
+type aesSuite struct{}
+
+func (s *aesSuite) Name() string { return "aes" }
+
+func (s *aesSuite) handshake(conn net.Conn, isServer bool, passphrase string) (io.Reader, io.Writer, error) {
+	key := deriveKey(passphrase)
+
+	serverNonce := make([]byte, aes.BlockSize)
+	clientNonce := make([]byte, aes.BlockSize)
+
+	if isServer {
+		if _, err := rand.Read(serverNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to generate server nonce: %w", err)
+		}
+		if _, err := conn.Write(serverNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to send server nonce: %w", err)
+		}
+		if _, err := io.ReadFull(conn, clientNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to read client nonce: %w", err)
+		}
+	} else {
+		if _, err := io.ReadFull(conn, serverNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to read server nonce: %w", err)
+		}
+		if _, err := rand.Read(clientNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to generate client nonce: %w", err)
+		}
+		if _, err := conn.Write(clientNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to send client nonce: %w", err)
+		}
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("secureio: failed to create AES cipher: %w", err)
+	}
+
+	serverToClientIV := deriveBytes(directionServerToClient, serverNonce, clientNonce, aes.BlockSize)
+	clientToServerIV := deriveBytes(directionClientToServer, serverNonce, clientNonce, aes.BlockSize)
+
+	var readStream, writeStream cipher.Stream
+	if isServer {
+		readStream = cipher.NewCTR(block, clientToServerIV)
+		writeStream = cipher.NewCTR(block, serverToClientIV)
+	} else {
+		readStream = cipher.NewCTR(block, serverToClientIV)
+		writeStream = cipher.NewCTR(block, clientToServerIV)
+	}
+
+	reader := &cipher.StreamReader{S: readStream, R: conn}
+	writer := &cipher.StreamWriter{S: writeStream, W: conn}
+
+	return bufio.NewReader(reader), writer, nil
+}
+
+type xorSuite struct{}
+
+func (s *xorSuite) Name() string { return "xor" }
+
+func (s *xorSuite) handshake(conn net.Conn, isServer bool, passphrase string) (io.Reader, io.Writer, error) {
+	key := deriveKey(passphrase)
+	serverNonce := make([]byte, 16)
+	clientNonce := make([]byte, 16)
+
+	if isServer {
+		if _, err := rand.Read(serverNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to generate server nonce: %w", err)
+		}
+		if _, err := conn.Write(serverNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to send server nonce: %w", err)
+		}
+		if _, err := io.ReadFull(conn, clientNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to read client nonce: %w", err)
+		}
+	} else {
+		if _, err := io.ReadFull(conn, serverNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to read server nonce: %w", err)
+		}
+		if _, err := rand.Read(clientNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to generate client nonce: %w", err)
+		}
+		if _, err := conn.Write(clientNonce); err != nil {
+			return nil, nil, fmt.Errorf("secureio: failed to send client nonce: %w", err)
+		}
+	}
+
+	serverToClientKey := mixKey(deriveBytes(directionServerToClient, serverNonce, clientNonce, len(key)), key)
+	clientToServerKey := mixKey(deriveBytes(directionClientToServer, serverNonce, clientNonce, len(key)), key)
+
+	var readKey, writeKey []byte
+	if isServer {
+		readKey = clientToServerKey
+		writeKey = serverToClientKey
+	} else {
+		readKey = serverToClientKey
+		writeKey = clientToServerKey
+	}
+
+	reader := &cipher.StreamReader{S: newXORStream(readKey), R: conn}
+	writer := &cipher.StreamWriter{S: newXORStream(writeKey), W: conn}
+	return bufio.NewReader(reader), writer, nil
+}
+
+type xorStream struct {
+	key []byte
+	pos int
+}
+
+func newXORStream(key []byte) cipher.Stream {
+	if len(key) == 0 {
+		panic("secureio: xor stream requires non-empty key")
+	}
+	copied := make([]byte, len(key))
+	copy(copied, key)
+	return &xorStream{key: copied}
+}
+
+func (x *xorStream) XORKeyStream(dst, src []byte) {
+	if len(x.key) == 0 {
+		panic("secureio: xor stream has empty key")
+	}
+	for i := range src {
+		dst[i] = src[i] ^ x.key[x.pos%len(x.key)]
+		x.pos++
+	}
+}
+
+func mixKey(input, key []byte) []byte {
+	if len(key) == 0 {
+		panic("secureio: cannot mix with empty key")
+	}
+	if len(input) == 0 {
+		return nil
+	}
+	result := make([]byte, len(input))
+	copy(result, input)
+	for i := range result {
+		result[i] ^= key[i%len(key)]
+	}
+	return result
+}
+
+// ListCipherSuites returns the names of all registered cipher suites.
+func ListCipherSuites() []string {
+	names := make([]string, 0, len(registeredSuites))
+	for name := range registeredSuites {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// RegisterCipherSuite allows external packages to register their own cipher suite
+// implementations. It returns an error if the name is already in use.
+func RegisterCipherSuite(name string, suite cipherSuite) error {
+	if name == "" {
+		return errors.New("secureio: cipher suite name cannot be empty")
+	}
+	if suite == nil {
+		return errors.New("secureio: cipher suite cannot be nil")
+	}
+	if _, exists := registeredSuites[name]; exists {
+		return fmt.Errorf("secureio: cipher suite %q already registered", name)
+	}
+	registeredSuites[name] = suite
+	return nil
+}

--- a/pkg/terminal/session.go
+++ b/pkg/terminal/session.go
@@ -1,0 +1,213 @@
+package terminal
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Options defines configuration values for an interactive shell session.
+type Options struct {
+	Prompt     string
+	Shell      string
+	InitialDir string
+}
+
+// Session models an interactive command execution environment similar to an
+// SSH shell.
+type Session struct {
+	rw     *bufio.ReadWriter
+	opts   Options
+	cwd    string
+	user   string
+	host   string
+	closed bool
+}
+
+// NewSession constructs a new interactive session over the provided reader and
+// writer. The reader and writer are typically backed by a secure network
+// connection.
+func NewSession(r io.Reader, w io.Writer, opts Options) (*Session, error) {
+	if opts.Shell == "" {
+		opts.Shell = "/bin/sh"
+	}
+
+	user := os.Getenv("USER")
+	if user == "" {
+		user = "user"
+	}
+
+	host, err := os.Hostname()
+	if err != nil {
+		host = "localhost"
+	}
+
+	cwd := opts.InitialDir
+	if cwd == "" {
+		if home := os.Getenv("HOME"); home != "" {
+			cwd = home
+		} else if pwd, err := os.Getwd(); err == nil {
+			cwd = pwd
+		} else {
+			cwd = "/"
+		}
+	}
+
+	return &Session{
+		rw:   bufio.NewReadWriter(bufio.NewReader(r), bufio.NewWriter(w)),
+		opts: opts,
+		cwd:  cwd,
+		user: user,
+		host: host,
+	}, nil
+}
+
+// Run starts the interactive loop, reading commands from the client and
+// returning when the client disconnects or explicitly exits the session.
+func (s *Session) Run() error {
+	if s.closed {
+		return errors.New("terminal: session already closed")
+	}
+	if err := s.writeLine("Welcome to the Go remote shell. Type 'exit' to disconnect."); err != nil {
+		return err
+	}
+
+	for {
+		if err := s.writePrompt(); err != nil {
+			return err
+		}
+
+		line, err := s.rw.ReadString('\n')
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		command := strings.TrimRight(line, "\r\n")
+		if command == "" {
+			continue
+		}
+
+		if command == "exit" {
+			if err := s.writeLine("Bye!"); err != nil {
+				return err
+			}
+			s.closed = true
+			return nil
+		}
+
+		if strings.HasPrefix(command, "cd") {
+			if err := s.handleCD(command); err != nil {
+				if err := s.writeLine(err.Error()); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		output, execErr := s.executeCommand(command)
+		if output != "" {
+			if err := s.writeString(output); err != nil {
+				return err
+			}
+		}
+		if execErr != nil {
+			if err := s.writeLine(execErr.Error()); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *Session) executeCommand(command string) (string, error) {
+	cmd := exec.Command(s.opts.Shell, "-c", command)
+	cmd.Env = os.Environ()
+	cmd.Dir = s.cwd
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func (s *Session) handleCD(command string) error {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "cd" {
+		if home := os.Getenv("HOME"); home != "" {
+			s.cwd = home
+			return nil
+		}
+		return errors.New("terminal: HOME not set")
+	}
+
+	parts := strings.Fields(trimmed)
+	if len(parts) < 2 {
+		return errors.New("terminal: cd requires a target directory")
+	}
+
+	target := parts[1]
+	if strings.HasPrefix(target, "~") {
+		if home := os.Getenv("HOME"); home != "" {
+			switch {
+			case target == "~":
+				target = home
+			case strings.HasPrefix(target, "~/"):
+				target = filepath.Join(home, target[2:])
+			}
+		}
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(s.cwd, target)
+	}
+
+	resolved, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("terminal: resolve directory: %w", err)
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return fmt.Errorf("terminal: cd: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("terminal: %s is not a directory", resolved)
+	}
+
+	s.cwd = resolved
+	return nil
+}
+
+func (s *Session) writePrompt() error {
+	prompt := s.opts.Prompt
+	if prompt == "" {
+		prompt = "{{.USER}}@{{.HOST}} {{.CWD}}$ "
+	}
+
+	prompt = strings.ReplaceAll(prompt, "{{.USER}}", s.user)
+	prompt = strings.ReplaceAll(prompt, "{{.HOST}}", s.host)
+	prompt = strings.ReplaceAll(prompt, "{{.CWD}}", s.cwd)
+	prompt = strings.ReplaceAll(prompt, "{{.BASENAME}}", filepath.Base(s.cwd))
+
+	if _, err := s.rw.WriteString(prompt); err != nil {
+		return err
+	}
+	return s.rw.Flush()
+}
+
+func (s *Session) writeLine(text string) error {
+	if _, err := s.rw.WriteString(text + "\n"); err != nil {
+		return err
+	}
+	return s.rw.Flush()
+}
+
+func (s *Session) writeString(text string) error {
+	if _, err := s.rw.WriteString(text); err != nil {
+		return err
+	}
+	return s.rw.Flush()
+}


### PR DESCRIPTION
## Summary
- add a secure I/O layer with AES and XOR cipher suites and an extension mechanism
- implement an interactive terminal session supporting prompts, cd, and command execution
- create configurable server and client binaries and document usage in the README

## Testing
- go build ./...
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca602bb8f0832da7534c81343b3aa7