### PR TITLE
Implement client-hosted interactive shell

### DIFF
--- a/pkg/terminal/options_io.go
+++ b/pkg/terminal/options_io.go
@@ -1,0 +1,44 @@
+package terminal
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// SendOptions transmits the provided session options over the writer using a
+// single JSON line.
+func SendOptions(w io.Writer, opts Options) error {
+	data, err := json.Marshal(opts)
+	if err != nil {
+		return fmt.Errorf("terminal: marshal session options: %w", err)
+	}
+
+	payload := append(data, '\n')
+	if _, err := w.Write(payload); err != nil {
+		return fmt.Errorf("terminal: send session options: %w", err)
+	}
+	return nil
+}
+
+// ReceiveOptions reads a single line JSON payload from the reader and decodes
+// it into session options.
+func ReceiveOptions(r *bufio.Reader) (Options, error) {
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return Options{}, fmt.Errorf("terminal: read session options: %w", err)
+	}
+
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return Options{}, fmt.Errorf("terminal: empty session options payload")
+	}
+
+	var opts Options
+	if err := json.Unmarshal(line, &opts); err != nil {
+		return Options{}, fmt.Errorf("terminal: decode session options: %w", err)
+	}
+	return opts, nil
+}

--- a/pkg/terminal/session.go
+++ b/pkg/terminal/session.go
@@ -1,7 +1,6 @@
 package terminal
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
 )
 
 // Options defines configuration values for an interactive shell session.
@@ -18,10 +20,11 @@ type Options struct {
 	InitialDir string
 }
 
-// Session models an interactive command execution environment similar to an
-// SSH shell.
+// Session models an interactive command execution environment backed by a
+// pseudo-terminal attached to a real shell on the host machine.
 type Session struct {
-	rw     *bufio.ReadWriter
+	reader io.Reader
+	writer io.Writer
 	opts   Options
 	cwd    string
 	user   string
@@ -57,131 +60,116 @@ func NewSession(r io.Reader, w io.Writer, opts Options) (*Session, error) {
 			cwd = "/"
 		}
 	}
+	if !filepath.IsAbs(cwd) {
+		if abs, err := filepath.Abs(cwd); err == nil {
+			cwd = abs
+		}
+	}
 
 	return &Session{
-		rw:   bufio.NewReadWriter(bufio.NewReader(r), bufio.NewWriter(w)),
-		opts: opts,
-		cwd:  cwd,
-		user: user,
-		host: host,
+		reader: r,
+		writer: w,
+		opts:   opts,
+		cwd:    cwd,
+		user:   user,
+		host:   host,
 	}, nil
 }
 
-// Run starts the interactive loop, reading commands from the client and
-// returning when the client disconnects or explicitly exits the session.
+// Run starts the interactive loop, bridging the encrypted transport with a
+// pseudo-terminal attached to the configured shell.
 func (s *Session) Run() error {
 	if s.closed {
 		return errors.New("terminal: session already closed")
 	}
-	if err := s.writeLine("Welcome to the Go remote shell. Type 'exit' to disconnect."); err != nil {
+
+	if _, err := io.WriteString(s.writer, "Welcome to the Go remote shell. Type 'exit' to disconnect.\r\n"); err != nil {
 		return err
 	}
 
-	for {
-		if err := s.writePrompt(); err != nil {
-			return err
-		}
-
-		line, err := s.rw.ReadString('\n')
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				return nil
-			}
-			return err
-		}
-
-		command := strings.TrimRight(line, "\r\n")
-		if command == "" {
-			continue
-		}
-
-		if command == "exit" {
-			if err := s.writeLine("Bye!"); err != nil {
-				return err
-			}
-			s.closed = true
-			return nil
-		}
-
-		if strings.HasPrefix(command, "cd") {
-			if err := s.handleCD(command); err != nil {
-				if err := s.writeLine(err.Error()); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
-		output, execErr := s.executeCommand(command)
-		if output != "" {
-			if err := s.writeString(output); err != nil {
-				return err
-			}
-		}
-		if execErr != nil {
-			if err := s.writeLine(execErr.Error()); err != nil {
-				return err
-			}
-		}
+	master, slave, err := openPTY()
+	if err != nil {
+		return fmt.Errorf("terminal: failed to allocate pty: %w", err)
 	}
-}
+	defer master.Close()
+	defer slave.Close()
 
-func (s *Session) executeCommand(command string) (string, error) {
-	cmd := exec.Command(s.opts.Shell, "-c", command)
-	cmd.Env = os.Environ()
+	cmd := exec.Command(s.opts.Shell)
+	cmd.Env = s.buildEnvironment()
 	cmd.Dir = s.cwd
-	output, err := cmd.CombinedOutput()
-	return string(output), err
+	cmd.Stdout = slave
+	cmd.Stdin = slave
+	cmd.Stderr = slave
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true, Setctty: true, Ctty: int(slave.Fd())}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("terminal: failed to start shell: %w", err)
+	}
+	_ = slave.Close()
+
+	var wg sync.WaitGroup
+	var copyErr error
+	var copyErrMu sync.Mutex
+
+	recordErr := func(err error) {
+		if err == nil || errors.Is(err, io.EOF) {
+			return
+		}
+		if errors.Is(err, os.ErrClosed) {
+			return
+		}
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) && errors.Is(pathErr.Err, os.ErrClosed) {
+			return
+		}
+		copyErrMu.Lock()
+		if copyErr == nil {
+			copyErr = err
+		}
+		copyErrMu.Unlock()
+	}
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, err := io.Copy(s.writer, master)
+		recordErr(err)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, err := io.Copy(master, s.reader)
+		recordErr(err)
+		_ = master.Close()
+	}()
+
+	waitErr := cmd.Wait()
+	wg.Wait()
+
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			recordErr(fmt.Errorf("terminal: shell exited with status: %w", exitErr))
+		} else {
+			recordErr(fmt.Errorf("terminal: shell wait error: %w", waitErr))
+		}
+	}
+
+	s.closed = true
+
+	return copyErr
 }
 
-func (s *Session) handleCD(command string) error {
-	trimmed := strings.TrimSpace(command)
-	if trimmed == "cd" {
-		if home := os.Getenv("HOME"); home != "" {
-			s.cwd = home
-			return nil
-		}
-		return errors.New("terminal: HOME not set")
+func (s *Session) buildEnvironment() []string {
+	env := os.Environ()
+	prompt := s.renderPrompt()
+	if prompt != "" {
+		env = append(env, fmt.Sprintf("PS1=%s", prompt))
 	}
-
-	parts := strings.Fields(trimmed)
-	if len(parts) < 2 {
-		return errors.New("terminal: cd requires a target directory")
-	}
-
-	target := parts[1]
-	if strings.HasPrefix(target, "~") {
-		if home := os.Getenv("HOME"); home != "" {
-			switch {
-			case target == "~":
-				target = home
-			case strings.HasPrefix(target, "~/"):
-				target = filepath.Join(home, target[2:])
-			}
-		}
-	}
-	if !filepath.IsAbs(target) {
-		target = filepath.Join(s.cwd, target)
-	}
-
-	resolved, err := filepath.Abs(target)
-	if err != nil {
-		return fmt.Errorf("terminal: resolve directory: %w", err)
-	}
-
-	info, err := os.Stat(resolved)
-	if err != nil {
-		return fmt.Errorf("terminal: cd: %w", err)
-	}
-	if !info.IsDir() {
-		return fmt.Errorf("terminal: %s is not a directory", resolved)
-	}
-
-	s.cwd = resolved
-	return nil
+	return env
 }
 
-func (s *Session) writePrompt() error {
+func (s *Session) renderPrompt() string {
 	prompt := s.opts.Prompt
 	if prompt == "" {
 		prompt = "{{.USER}}@{{.HOST}} {{.CWD}}$ "
@@ -189,25 +177,56 @@ func (s *Session) writePrompt() error {
 
 	prompt = strings.ReplaceAll(prompt, "{{.USER}}", s.user)
 	prompt = strings.ReplaceAll(prompt, "{{.HOST}}", s.host)
-	prompt = strings.ReplaceAll(prompt, "{{.CWD}}", s.cwd)
-	prompt = strings.ReplaceAll(prompt, "{{.BASENAME}}", filepath.Base(s.cwd))
+	prompt = strings.ReplaceAll(prompt, "{{.CWD}}", "\\w")
+	prompt = strings.ReplaceAll(prompt, "{{.BASENAME}}", "\\W")
 
-	if _, err := s.rw.WriteString(prompt); err != nil {
-		return err
-	}
-	return s.rw.Flush()
+	return prompt
 }
 
-func (s *Session) writeLine(text string) error {
-	if _, err := s.rw.WriteString(text + "\n"); err != nil {
-		return err
+func openPTY() (*os.File, *os.File, error) {
+	fd, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC|syscall.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, fmt.Errorf("terminal: open /dev/ptmx: %w", err)
 	}
-	return s.rw.Flush()
+
+	if err := unlockPT(fd); err != nil {
+		_ = syscall.Close(fd)
+		return nil, nil, err
+	}
+
+	name, err := ptsName(fd)
+	if err != nil {
+		_ = syscall.Close(fd)
+		return nil, nil, err
+	}
+
+	// Ensure the slave node is accessible to the current user.
+	_ = syscall.Chown(name, os.Getuid(), os.Getgid())
+	_ = syscall.Chmod(name, 0o600)
+
+	slaveFD, err := syscall.Open(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		_ = syscall.Close(fd)
+		return nil, nil, fmt.Errorf("terminal: open slave pty: %w", err)
+	}
+
+	master := os.NewFile(uintptr(fd), "pty-master")
+	slave := os.NewFile(uintptr(slaveFD), "pty-slave")
+	return master, slave, nil
 }
 
-func (s *Session) writeString(text string) error {
-	if _, err := s.rw.WriteString(text); err != nil {
-		return err
+func unlockPT(fd int) error {
+	var unlock int32
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSPTLCK), uintptr(unsafe.Pointer(&unlock))); errno != 0 {
+		return fmt.Errorf("terminal: unlock pty: %w", syscall.Errno(errno))
 	}
-	return s.rw.Flush()
+	return nil
+}
+
+func ptsName(fd int) (string, error) {
+	var n uint32
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGPTN), uintptr(unsafe.Pointer(&n))); errno != 0 {
+		return "", fmt.Errorf("terminal: ptsname: %w", syscall.Errno(errno))
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
 }


### PR DESCRIPTION
## Summary
- move the interactive shell session to the client and expose it through a PTY
- add an options exchange so the server can configure the client session
- update the server to act as a controller, forwarding input/output and signals, and refresh the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca652c51f8832d935ec8061c1d23d0