### PR TITLE
Implement PTY-based reverse shell orientation

### DIFF
--- a/cmd/server/term_linux.go
+++ b/cmd/server/term_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type terminalState struct {
+	termios syscall.Termios
+}
+
+func isTerminal(fd int) bool {
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&termios)))
+	return errno == 0
+}
+
+func makeRaw(fd int) (*terminalState, error) {
+	var old syscall.Termios
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&old))); errno != 0 {
+		return nil, errno
+	}
+
+	newState := old
+	newState.Iflag &^= syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IXON
+	newState.Oflag &^= syscall.OPOST
+	newState.Lflag &^= syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
+	newState.Cflag &^= syscall.CSIZE | syscall.PARENB
+	newState.Cflag |= syscall.CS8
+	newState.Cc[syscall.VMIN] = 1
+	newState.Cc[syscall.VTIME] = 0
+
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&newState))); errno != 0 {
+		return nil, errno
+	}
+
+	return &terminalState{termios: old}, nil
+}
+
+func restore(fd int, state *terminalState) error {
+	if state == nil {
+		return nil
+	}
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&state.termios)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/pkg/terminal/pty_linux.go
+++ b/pkg/terminal/pty_linux.go
@@ -1,0 +1,61 @@
+//go:build linux
+
+package terminal
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	_TIOCGPTN   = 0x80045430
+	_TIOCSPTLCK = 0x40045431
+)
+
+func startPTY(cmd *exec.Cmd) (*os.File, error) {
+	fd, err := syscall.Open("/dev/ptmx", syscall.O_RDWR|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("terminal: open ptmx: %w", err)
+	}
+
+	master := os.NewFile(uintptr(fd), "/dev/ptmx")
+
+	unlock := uint32(0)
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, master.Fd(), uintptr(_TIOCSPTLCK), uintptr(unsafe.Pointer(&unlock))); errno != 0 {
+		master.Close()
+		return nil, fmt.Errorf("terminal: unlock ptmx: %w", errno)
+	}
+
+	var ptyNumber uint32
+	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, master.Fd(), uintptr(_TIOCGPTN), uintptr(unsafe.Pointer(&ptyNumber))); errno != 0 {
+		master.Close()
+		return nil, fmt.Errorf("terminal: get pty number: %w", errno)
+	}
+
+	slavePath := fmt.Sprintf("/dev/pts/%d", ptyNumber)
+	slave, err := os.OpenFile(slavePath, os.O_RDWR, 0)
+	if err != nil {
+		master.Close()
+		return nil, fmt.Errorf("terminal: open slave pty: %w", err)
+	}
+	defer slave.Close()
+
+	cmd.Stdout = slave
+	cmd.Stdin = slave
+	cmd.Stderr = slave
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setctty: true,
+		Setsid:  true,
+		Ctty:    int(slave.Fd()),
+	}
+
+	if err := cmd.Start(); err != nil {
+		master.Close()
+		return nil, fmt.Errorf("terminal: start command: %w", err)
+	}
+
+	return master, nil
+}


### PR DESCRIPTION
## Summary
- reverse the connection flow so the server acts as the controller and the client exposes its shell
- add a PTY-backed session implementation to deliver a fully interactive remote shell with prompt customization
- document the new behavior and usage pattern in the README

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca652c51f8832d935ec8061c1d23d0