### PR TITLE
Implement AES-GCM encrypted transport with password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simulate a fully interactive SSH-style shell terminal environment using Go to ex
 - Long-lived TCP connections between server and client.
 - **Reverse** interactive shell: the server listens for inbound clients and, once connected, receives a full PTY-backed shell from the client machine.
 - Fully interactive remote shell with history keys, readline support, and terminal control sequences.
-- Pluggable stream encryption with selectable cipher suites (`aes`, `xor`) and the ability to register custom algorithms.
+- AES-GCM encrypted transport with explicit password authentication before a session is established.
 - Configurable prompt template, initial working directory, and shell executable provided by the client.
 
 ## Building
@@ -19,16 +19,16 @@ go build ./cmd/client
 
 ## Usage
 
-Start the server (listen on port 2222 by default):
+Start the server (listen on port 9999 by default):
 
 ```bash
-./server -pass mysecret -listen 0.0.0.0:2222 -cipher aes
+./server --listen 0.0.0.0:9999 --aes-key <hex-encoded-key> --auth-password <shared-password>
 ```
 
 Launch the client on the machine you wish to control:
 
 ```bash
-./client -addr 127.0.0.1:2222 -pass mysecret -cipher aes
+./client --server 127.0.0.1:9999 --aes-key <hex-encoded-key> --auth-password <shared-password>
 ```
 
 Once the handshake completes, the server terminal is switched to raw mode and bridged directly to the client's shell. History keys (↑/↓), interactive programs, and terminal escape sequences now behave exactly like an SSH session. Use `exit` inside the remote shell to terminate the connection.
@@ -47,20 +47,11 @@ The client accepts a `-prompt` flag allowing placeholders that are expanded befo
 For example, to emulate the default bash prompt:
 
 ```bash
-./client -pass mysecret -prompt "{{.USER}}@{{.HOST}} {{.BASENAME}}$ "
+./client --aes-key <hex-encoded-key> --auth-password <shared-password> --prompt "{{.USER}}@{{.HOST}} {{.BASENAME}}$ "
 ```
-
-### Cipher suites
-
-Two cipher suites are included:
-
-- `aes` – AES-CTR mode with per-session nonces and independent streams for each direction.
-- `xor` – lightweight XOR stream cipher derived from the shared secret (demonstrates how to plug in custom algorithms; use for testing only).
-
-Additional ciphers can be registered at runtime using `secureio.RegisterCipherSuite`.
 
 ### Notes
 
-- Both server and client must be launched with the same passphrase and cipher suite.
+- Both server and client must be launched with the same AES key and authentication password.
 - The client can choose a different shell binary via `-shell` (defaults to `/bin/sh`) and initial working directory via `-workdir`.
 - Keep the terminal window open on the server while the client is connected to maintain the long-lived session.


### PR DESCRIPTION
## Summary
- replace the existing cipher suite abstraction with an AES-GCM transport that authenticates clients before starting the PTY bridge
- update the client and server CLIs to pass AES keys and authentication passwords, generating secure defaults on the server when omitted
- refresh the documentation to describe the new startup flags and encryption model

## Testing
- go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca6b2b987c832da56edc40a1c07a11