### PR TITLE
Add client daemonization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Launch the client on the machine you wish to control:
 ./client --server 127.0.0.1:9999 --aes-key <hex-encoded-key> --auth-password <shared-password>
 ```
 
+After a successful handshake the client detaches into the background on Linux systems, closes its standard file descriptors, and
+continues streaming shell traffic to the server. Log messages are forwarded to the host syslog facility. Use the `--foreground`
+flag to keep the process attached to the current terminal or when running on non-Linux platforms where daemonization is
+unavailable.
+
 Once the handshake completes, the server terminal is switched to raw mode and bridged directly to the client's shell. History keys (↑/↓), interactive programs, and terminal escape sequences now behave exactly like an SSH session. Use `exit` inside the remote shell to terminate the connection.
 
 > **Note:** Because the remote shell runs on the client, only one interactive session can be active per server process.
@@ -54,4 +59,5 @@ For example, to emulate the default bash prompt:
 
 - Both server and client must be launched with the same AES key and authentication password.
 - The client can choose a different shell binary via `-shell` (defaults to `/bin/sh`) and initial working directory via `-workdir`.
+- Specify `--foreground` to disable background mode and stream logs directly to the invoking terminal.
 - Keep the terminal window open on the server while the client is connected to maintain the long-lived session.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ Launch the client on the machine you wish to control:
 ./client --server 127.0.0.1:9999 --aes-key <hex-encoded-key> --auth-password <shared-password>
 ```
 
-After a successful handshake the client detaches into the background on Linux systems, closes its standard file descriptors, and
-continues streaming shell traffic to the server. Log messages are forwarded to the host syslog facility. Use the `--foreground`
-flag to keep the process attached to the current terminal or when running on non-Linux platforms where daemonization is
-unavailable.
+On Linux the client automatically spawns a detached background copy that connects to the server, closes its standard file
+descriptors, and streams shell traffic while logging to the host syslog facility. Use the `--foreground` flag to keep the process
+attached to the current terminal or when running on non-Linux platforms where daemonization is unavailable.
 
 Once the handshake completes, the server terminal is switched to raw mode and bridged directly to the client's shell. History keys (↑/↓), interactive programs, and terminal escape sequences now behave exactly like an SSH session. Use `exit` inside the remote shell to terminate the connection.
 

--- a/cmd/client/daemon_linux.go
+++ b/cmd/client/daemon_linux.go
@@ -1,0 +1,74 @@
+//go:build linux
+
+package main
+
+import (
+	"io"
+	"log"
+	"log/syslog"
+	"os"
+	"syscall"
+)
+
+const daemonSupported = true
+
+func daemonize() error {
+	pid, err := fork()
+	if err != nil {
+		return err
+	}
+	if pid > 0 {
+		os.Exit(0)
+	}
+
+	if _, err := syscall.Setsid(); err != nil {
+		return err
+	}
+
+	pid, err = fork()
+	if err != nil {
+		return err
+	}
+	if pid > 0 {
+		os.Exit(0)
+	}
+
+	if err := os.Chdir("/"); err != nil {
+		return err
+	}
+	syscall.Umask(0)
+
+	nullFile, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer nullFile.Close()
+
+	if err := syscall.Dup2(int(nullFile.Fd()), int(os.Stdin.Fd())); err != nil {
+		return err
+	}
+	if err := syscall.Dup2(int(nullFile.Fd()), int(os.Stdout.Fd())); err != nil {
+		return err
+	}
+	if err := syscall.Dup2(int(nullFile.Fd()), int(os.Stderr.Fd())); err != nil {
+		return err
+	}
+
+	writer, err := syslog.New(syslog.LOG_DAEMON|syslog.LOG_INFO, "revshell-client")
+	if err != nil {
+		log.SetOutput(io.Discard)
+	} else {
+		log.SetOutput(writer)
+	}
+	log.SetFlags(log.LstdFlags)
+
+	return nil
+}
+
+func fork() (int, error) {
+	r1, _, errno := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(r1), nil
+}

--- a/cmd/client/daemon_other.go
+++ b/cmd/client/daemon_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package main
+
+const daemonSupported = false
+
+func daemonize() error {
+	return nil
+}

--- a/cmd/client/daemon_other.go
+++ b/cmd/client/daemon_other.go
@@ -4,6 +4,10 @@ package main
 
 const daemonSupported = false
 
-func daemonize() (bool, error) {
+func daemonize(opts *clientOptions) (bool, error) {
 	return false, nil
+}
+
+func finalizeDaemonEnvironment() error {
+	return nil
 }

--- a/cmd/client/daemon_other.go
+++ b/cmd/client/daemon_other.go
@@ -4,6 +4,6 @@ package main
 
 const daemonSupported = false
 
-func daemonize() error {
-	return nil
+func daemonize() (bool, error) {
+	return false, nil
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -42,8 +42,12 @@ func main() {
 			log.Printf("client: background mode is only supported on Linux; continuing in foreground")
 		} else {
 			log.Printf("client: handshake successful, entering background mode")
-			if err := daemonize(); err != nil {
+			shouldExit, err := daemonize()
+			if err != nil {
 				log.Fatalf("client: failed to daemonize: %v", err)
+			}
+			if shouldExit {
+				return
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- add a Linux-specific daemonize helper for the client that double-forks, detaches stdio, and routes logs to syslog
- invoke daemonization after the secure handshake, with a --foreground flag to keep the session attached or when running on non-Linux hosts
- document the new background behavior and flag in the README

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ca72f6b0c8832dab0710fc371aea53