### PR TITLE
Daemonize client on startup

### DIFF
--- a/cmd/client/daemon_stub.go
+++ b/cmd/client/daemon_stub.go
@@ -1,0 +1,7 @@
+//go:build windows || plan9
+
+package main
+
+func daemonize() error {
+	return nil
+}

--- a/cmd/client/daemon_unix.go
+++ b/cmd/client/daemon_unix.go
@@ -1,0 +1,47 @@
+//go:build !windows && !plan9
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const daemonEnvKey = "REVSH_CLIENT_DAEMONIZED"
+
+func daemonize() error {
+	if os.Getenv(daemonEnvKey) == "1" {
+		return nil
+	}
+
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable path: %w", err)
+	}
+
+	args := append([]string{exePath}, os.Args[1:]...)
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", os.DevNull, err)
+	}
+
+	env := append(os.Environ(), daemonEnvKey+"=1")
+	attr := &syscall.ProcAttr{
+		Env:   env,
+		Files: []uintptr{devNull.Fd(), devNull.Fd(), devNull.Fd()},
+		Sys: &syscall.SysProcAttr{
+			Setsid: true,
+		},
+	}
+
+	if _, err := syscall.ForkExec(exePath, args, attr); err != nil {
+		devNull.Close()
+		return fmt.Errorf("fork exec: %w", err)
+	}
+
+	devNull.Close()
+	os.Exit(0)
+	return nil
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -25,6 +25,10 @@ type clientOptions struct {
 func main() {
 	opts := parseFlags()
 
+	if err := daemonize(); err != nil {
+		log.Fatalf("client: failed to daemonize: %v", err)
+	}
+
 	conn, err := net.Dial("tcp", opts.addr)
 	if err != nil {
 		log.Fatalf("client: failed to connect to %s: %v", opts.addr, err)


### PR DESCRIPTION
## Summary
- run the client as a background daemon by default on Unix platforms
- add environment guard to avoid recursive daemonization and detach stdio to /dev/null
- provide a no-op daemonize implementation for Windows and Plan 9 builds

## Testing
- go build ./cmd/client && go build ./cmd/server

------
https://chatgpt.com/codex/tasks/task_e_68ca7e412ea4832dadfbec098ecf5be6