### PR TITLE
Preserve server terminal scrollback buffer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -130,8 +130,16 @@ func handleConnection(conn net.Conn, opts serverOptions) error {
 	doneReading := make(chan error, 1)
 	doneWriting := make(chan error, 1)
 
+	stdout := newScrollbackWriter(os.Stdout)
 	go func() {
-		_, err := io.Copy(os.Stdout, reader)
+		_, err := io.Copy(stdout, reader)
+		if flushErr := stdout.Flush(); flushErr != nil {
+			if err == nil {
+				err = flushErr
+			} else {
+				log.Printf("server: failed to flush terminal output: %v", flushErr)
+			}
+		}
 		doneReading <- err
 	}()
 

--- a/cmd/server/output_filter.go
+++ b/cmd/server/output_filter.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"io"
+)
+
+var clearScrollSequence = []byte{0x1b, '[', '3', 'J'}
+
+// scrollbackWriter strips sequences that clear the terminal scrollback buffer
+// while forwarding all other bytes to the wrapped writer. Some remote shells
+// emit ESC[3J (e.g. via `clear`) which erases the local scrollback and prevents
+// the operator from reviewing long command output using the terminal scrollbar.
+// By filtering those sequences we preserve the scrollback history without
+// altering on-screen behaviour.
+type scrollbackWriter struct {
+	dest io.Writer
+	buf  []byte
+}
+
+func newScrollbackWriter(w io.Writer) *scrollbackWriter {
+	return &scrollbackWriter{dest: w}
+}
+
+// Write removes any occurrences of ESC[3J from the stream and forwards the
+// remaining bytes to the destination writer. Partial matches are buffered so
+// split sequences are handled correctly across multiple writes.
+func (w *scrollbackWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+
+	for {
+		idx := bytes.Index(w.buf, clearScrollSequence)
+		if idx == -1 {
+			break
+		}
+
+		if idx > 0 {
+			if _, err := w.dest.Write(w.buf[:idx]); err != nil {
+				return 0, err
+			}
+		}
+
+		// Drop the ESC[3J sequence.
+		w.buf = w.buf[idx+len(clearScrollSequence):]
+	}
+
+	keep := longestSuffixPrefix(w.buf, clearScrollSequence)
+	if writeLen := len(w.buf) - keep; writeLen > 0 {
+		if _, err := w.dest.Write(w.buf[:writeLen]); err != nil {
+			return 0, err
+		}
+		w.buf = w.buf[writeLen:]
+	}
+
+	return len(p), nil
+}
+
+// Flush writes any buffered data that may represent the start of a filtered
+// sequence but never completed.
+func (w *scrollbackWriter) Flush() error {
+	if len(w.buf) == 0 {
+		return nil
+	}
+	if _, err := w.dest.Write(w.buf); err != nil {
+		return err
+	}
+	w.buf = nil
+	return nil
+}
+
+func longestSuffixPrefix(buf, pattern []byte) int {
+	max := len(pattern) - 1
+	if max <= 0 {
+		return 0
+	}
+	if max > len(buf) {
+		max = len(buf)
+	}
+	for i := max; i > 0; i-- {
+		if bytes.Equal(buf[len(buf)-i:], pattern[:i]) {
+			return i
+		}
+	}
+	return 0
+}

--- a/cmd/server/output_filter_test.go
+++ b/cmd/server/output_filter_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestScrollbackWriterFiltersClearScrollback(t *testing.T) {
+	var buf bytes.Buffer
+	w := newScrollbackWriter(&buf)
+
+	input := []byte("hello\x1b[3Jworld")
+	if _, err := w.Write(input); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	if got := buf.String(); got != "helloworld" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestScrollbackWriterHandlesSplitSequences(t *testing.T) {
+	var buf bytes.Buffer
+	w := newScrollbackWriter(&buf)
+
+	if _, err := w.Write([]byte("foo\x1b[")); err != nil {
+		t.Fatalf("first write failed: %v", err)
+	}
+	if _, err := w.Write([]byte("3Jbar")); err != nil {
+		t.Fatalf("second write failed: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	if got := buf.String(); got != "foobar" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestScrollbackWriterLeavesUnrelatedEscapeSequences(t *testing.T) {
+	var buf bytes.Buffer
+	w := newScrollbackWriter(&buf)
+
+	if _, err := w.Write([]byte("foo\x1b[2Jbar")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+
+	if got := buf.Bytes(); !bytes.Equal(got, []byte("foo\x1b[2Jbar")) {
+		t.Fatalf("unexpected output bytes: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a scrollback-preserving writer that filters out ESC[3J so remote shells cannot erase the local scrollback
- route server output through the filtered writer and handle flush errors when copying data to stdout
- cover the new writer with unit tests, including split-sequence handling

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cb70c18b04832db7c4740d6bd246dd